### PR TITLE
Update local.conf

### DIFF
--- a/yocto/meta-sabaton/conf/local.conf
+++ b/yocto/meta-sabaton/conf/local.conf
@@ -13,7 +13,9 @@
 
 # MULTICONFIG SELECTION
 BBMULTICONFIG = "aarch64 armv7"
-
+LICENSE_FLAGS_ACCEPTED += "commercial"
+NDK_VERSION = "0.6"
+SDKPATHINSTALL = "/opt/sabaton/${NDK_VERSION}"
 #
 # Machine Selection
 #


### PR DESCRIPTION
whitelist a commercial license and SDKPATHINSTALL is set to /opt/sabaton/<ndk_version>