### PR TITLE
Disabled DBus functionality in pipewire to avoid the session bus depe…

### DIFF
--- a/yocto/meta-sabaton/recipes-multimedia/pipewire/pipewire_1.0.0.bb
+++ b/yocto/meta-sabaton/recipes-multimedia/pipewire/pipewire_1.0.0.bb
@@ -53,6 +53,7 @@ SYSTEMD_PACKAGES = "${PN}"
 # their PipeWire configuration files.
 EXTRA_OEMESON += " \
     -Devl=disabled \
+    -Ddbus=disabled \
     -Dtests=disabled \
     -Dudevrulesdir=${nonarch_base_libdir}/udev/rules.d/ \
     -Dsystemd-system-unit-dir=${systemd_system_unitdir} \


### PR DESCRIPTION
Disabled DBus functionality in pipewire to avoid the session bus dependency